### PR TITLE
Add catalog v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are some [limitations](doc/limitations.md) to a catalog-based approach, me
 `octocatalog-diff` is currently able to get catalogs by the following methods:
 - Compile catalog via the command line with a Puppet agent on your machine (as GitHub uses the tool internally)
 - Obtain catalog over the network from PuppetDB
-- Obtain catalog over the network using the API to query a Puppet Master / PuppetServer (Puppet 3.x and 4.x supported)
+- Obtain catalog over the network using the API to query a Puppet Master / PuppetServer (Puppet 3.x through 6.x supported)
 - Read catalog from a JSON file
 
 ## Example

--- a/doc/advanced-puppet-master.md
+++ b/doc/advanced-puppet-master.md
@@ -8,7 +8,11 @@ Please note the following caveats:
 
 0. You will need to deploy your Puppet code to an environment on your Puppet Master prior to running `octocatalog-diff` for that environment. `octocatalog-diff` does not deploy code for you.
 
-0. You will need to configure authorization for one or more whitelisted certificates on your Puppet Master. The default permissions allow a node to retrieve its own catalog via the API, but you need a certificate for `octocatalog-diff` that permits it to retrieve any catalog. See the [Certificate authorization](#certificate-authorization) section below.
+0. You will need to configure authorization for one or more whitelisted certificates on your Puppet Master. The default permissions allow a node to retrieve its own catalog via the API, but you need a certificate for `octocatalog-diff` that permits it to retrieve any catalog. See the [Certificate authorization](#certificate-authorization) section below. If you are using Puppet Enterprise and use
+the Puppet Master v4 API you may also use a Puppet Enterprise RBAC token. The user the token was
+issued to will need the "Puppet Server Compile catalogs for remote nodes" permission.
+
+0. If you are using the v2 or v3 APIs to compile catalogs against your PuppetServer those systems will store the facts you send in and catalogs generated in their PuppetDB instances. This can be dangerous if your environment depends on the use and collection of exported resources or an accurate representation of the fact data in PuppetDB. When using the v4 API the facts and catalogs will, by default, not be updated in PuppetDB as a result of the compile. If you wish to update them, you must specify one of the associated options to enable that behavior.
 
 ## Command line options
 
@@ -18,11 +22,15 @@ The following command line options are used to retrieve a catalog from a Puppet 
 | ------ | ----------- |
 | `-f ENVIRONMENT` | Environment name to use for the "from" catalog |
 | `-t ENVIRONMENT` | Environment name to use for the "to" catalog |
-| `--puppet-master HOSTNAME:PORT | The hostname and port number of the Puppet Master. (By default the port used by Puppet Master is 8140.) |
-| `--puppet-master-api-version VERSION | The API version used by the Puppet Master. API versions 2 and 3 are supported. Puppet Master 3.x uses API version 2, and the PuppetServer for Puppet 4.x uses API version 3. By default, API version 3 is used, so you only need to set this option if you are using Puppet Master 3.x. |
+| `--puppet-master HOSTNAME:PORT` | The hostname and port number of the Puppet Master. (By default the port used by Puppet Master is 8140.) |
+| `--puppet-master-api-version VERSION` | The API version used by the Puppet Master. API versions 2, 3,and 4 are supported. Puppet Master 3.x uses API version 2, and the PuppetServer for Puppet 4.x uses API version 3. PuppetServer 6.3.0 introduced the v4 API. By default, API version 3 is used, so you only need to set this option if you are using Puppet Master 3.x or wish to use the newer v4 API. |
 | `--puppet-master-ssl-ca PATH` | Path to the CA certificate (public portion of certificate only) for your Puppet Master. This file will be on your Puppet Master and all Puppet agents. You can find it by running `puppet config print cacert` on any Puppet-managed host. |
-| `--puppet-master-ssl-client-cert PATH` | Path to the client certificate. Please see the section below on certificate authentication. |
-| `--puppet-master-ssl-client-key PATH` | Path to the client private key. Please see the section below on certificate authentication. |
+| `--puppet-master-ssl-client-cert PATH` | Path to the client certificate. Please see the section below on certificate authentication. This can be omitted if using PE RBAC token based auth with the v4 API. |
+| `--puppet-master-ssl-client-key PATH` | Path to the client private key. Please see the section below on certificate authentication. This can be omitted if using PE RBAC token based auth with the v4 API. |
+| `--puppet-master-token STRING` | A PE RBAC token used to authenticate a v4 catalog compile, in lieu of using certificate authentication. Please see the section below on token authentication. |
+| `--puppet-master-token-file PATH` | A path to a file containing a PE RBAC token used to authenticate a v4 catalog compile, in lieu of using certificate authentication. If this and `--puppet-master-token` are both specified, `--puppet-master-token` will be used instead. Please see the section below on token authentication. |
+| `--puppet-master-update-catalog` | When using the v4 API, instruct the PuppetServer to update the catalog generated from the compile in its PuppetDB instance. When using v2 and v3 APIs the catalog is always updated and this option is ignored. |
+| `--puppet-master-update-facts` | When using the v4 API, instruct the PuppetServer to update the facts used during the compile in its PuppetDB instance. When using v2 and v3 APIs the facts are always updated and this option is ignored. |
 
 If you wish to use a different Puppet Master to compile the "to" and "from" catalogs, you may prefix any of the `--puppet-master...` options with `to` or `from`. For example, perhaps you are testing an upgrade from Puppet 3.x to 4.x. You could use:
 
@@ -48,3 +56,13 @@ allow $1
 ```
 
 Please follow the instructions for the version of Puppet Master, PuppetServer, or Puppet Enterprise that you are using in order to generate and authorize the certificates.
+
+## PE RBAC Token authorization
+
+In newer versions of Puppet Enterprise you can authenticate using a valid PE RBAC token with appropriate permissions as long as it is authorized in the PuppetServer `auth.conf` file.
+
+By default this permission is enabled and controlled by the `puppet_enterprise::master::tk_authz::allow_rbac_catalog_compile` Hiera setting.
+
+The user the token was issued to must have the `puppetserver:compile_catalogs:*` permission.
+
+Note: `octocatalog-diff` will automatically obscure any secrets marked as `Sensitive` when displaying differences, but the above RBAC permission does give uses the ability to retrieve catalogs with all secrets, even ones marked `Sensitive`, visible.

--- a/lib/octocatalog-diff/catalog.rb
+++ b/lib/octocatalog-diff/catalog.rb
@@ -191,6 +191,8 @@ module OctocatalogDiff
       build
       raise OctocatalogDiff::Errors::CatalogError, 'Catalog does not appear to have been built' if !valid? && error_message.nil?
       raise OctocatalogDiff::Errors::CatalogError, error_message unless valid?
+      # Handle the structure returned by the /puppet/v4/catalog Puppetserver endpoint:
+      return @catalog['catalog']['resources'] if @catalog['catalog'].is_a?(Hash) && @catalog['catalog']['resources'].is_a?(Array)
       return @catalog['data']['resources'] if @catalog['data'].is_a?(Hash) && @catalog['data']['resources'].is_a?(Array)
       return @catalog['resources'] if @catalog['resources'].is_a?(Array)
       # This is a bug condition

--- a/lib/octocatalog-diff/cli/options/puppet_master_api_version.rb
+++ b/lib/octocatalog-diff/cli/options/puppet_master_api_version.rb
@@ -14,8 +14,8 @@ OctocatalogDiff::Cli::Options::Option.newoption(:puppet_master_api_version) do
       options: options,
       cli_name: 'puppet-master-api-version',
       option_name: 'puppet_master_api_version',
-      desc: 'Puppet Master API version (2 for Puppet 3.x, 3 for Puppet 4.x)',
-      validator: ->(x) { x =~ /^[23]$/ || raise(ArgumentError, 'Only API versions 2 and 3 are supported') },
+      desc: 'Puppet Master API version (2 for Puppet 3.x, 3 for Puppet 4.x, 4 for Puppet Server >= 6.3.0)',
+      validator: ->(x) { x =~ /^[234]$/ || raise(ArgumentError, 'Only API versions 2, 3, and 4 are supported') },
       translator: ->(x) { x.to_i }
     )
   end

--- a/lib/octocatalog-diff/cli/options/puppet_master_token.rb
+++ b/lib/octocatalog-diff/cli/options/puppet_master_token.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Specify a PE RBAC token used to authenticate to Puppetserver for v4
+# catalog API calls.
+# @param parser [OptionParser object] The OptionParser argument
+# @param options [Hash] Options hash being constructed; this is modified in this method.
+OctocatalogDiff::Cli::Options::Option.newoption(:puppet_master_token) do
+  has_weight 310
+
+  def parse(parser, options)
+    OctocatalogDiff::Cli::Options.option_globally_or_per_branch(
+      parser: parser,
+      options: options,
+      datatype: '',
+      cli_name: 'puppet-master-token',
+      option_name: 'puppet_master_token',
+      desc: 'PE RBAC token to authenticate to the Puppetserver API v4'
+    )
+  end
+end

--- a/lib/octocatalog-diff/cli/options/puppet_master_token_file.rb
+++ b/lib/octocatalog-diff/cli/options/puppet_master_token_file.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Specify a path to a file containing a PE RBAC token used to authenticate to the
+# Puppetserver for a v4 catalog API call.
+# @param parser [OptionParser object] The OptionParser argument
+# @param options [Hash] Options hash being constructed; this is modified in this method.
+OctocatalogDiff::Cli::Options::Option.newoption(:puppet_master_token_file) do
+  has_weight 300
+
+  def parse(parser, options)
+    OctocatalogDiff::Cli::Options.option_globally_or_per_branch(
+      parser: parser,
+      options: options,
+      datatype: '',
+      cli_name: 'puppet-master-token-file',
+      option_name: 'puppet_master_token_file',
+      desc: 'File containing PE RBAC token to authenticate to the Puppetserver API v4',
+      translator: ->(x) { x.start_with?('/', '~') ? x : File.join(options[:basedir], x) },
+      post_process: lambda do |opts|
+        %w(to from).each do |prefix|
+          fileopt = "#{prefix}_puppet_master_token_file".to_sym
+          tokenopt = "#{prefix}_puppet_master_token".to_sym
+
+          tokenfile = opts[fileopt]
+          next if tokenfile.nil?
+
+          raise(Errno::ENOENT, "Token file #{tokenfile} is not readable") unless File.readable?(tokenfile)
+
+          token = File.read(tokenfile).strip
+          opts[tokenopt] ||= token
+        end
+      end
+    )
+  end
+end

--- a/lib/octocatalog-diff/cli/options/puppet_master_update_catalog.rb
+++ b/lib/octocatalog-diff/cli/options/puppet_master_update_catalog.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Specify if, when using the Puppetserver v4 catalog API, the Puppetserver should
+# update the catalog in PuppetDB.
+# @param parser [OptionParser object] The OptionParser argument
+# @param options [Hash] Options hash being constructed; this is modified in this method.
+OctocatalogDiff::Cli::Options::Option.newoption(:puppet_master_update_catalog) do
+  has_weight 320
+
+  def parse(parser, options)
+    OctocatalogDiff::Cli::Options.option_globally_or_per_branch(
+      parser: parser,
+      options: options,
+      datatype: false,
+      cli_name: 'puppet-master-update-catalog',
+      option_name: 'puppet_master_update_catalog',
+      desc: 'Update catalog in PuppetDB when using Puppetmaster API version 4'
+    )
+  end
+end

--- a/lib/octocatalog-diff/cli/options/puppet_master_update_facts.rb
+++ b/lib/octocatalog-diff/cli/options/puppet_master_update_facts.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Specify if, when using the Puppetserver v4 catalog API, the Puppetserver should
+# update the facts in PuppetDB.
+# @param parser [OptionParser object] The OptionParser argument
+# @param options [Hash] Options hash being constructed; this is modified in this method.
+OctocatalogDiff::Cli::Options::Option.newoption(:puppet_master_update_facts) do
+  has_weight 320
+
+  def parse(parser, options)
+    OctocatalogDiff::Cli::Options.option_globally_or_per_branch(
+      parser: parser,
+      options: options,
+      datatype: false,
+      cli_name: 'puppet-master-update-facts',
+      option_name: 'puppet_master_update_facts',
+      desc: 'Update facts in PuppetDB when using Puppetmaster API version 4'
+    )
+  end
+end

--- a/spec/octocatalog-diff/fixtures/catalogs/tiny-catalog-v4-api.json
+++ b/spec/octocatalog-diff/fixtures/catalogs/tiny-catalog-v4-api.json
@@ -1,0 +1,41 @@
+{
+  "catalog": {
+    "tags": ["settings"],
+    "name": "my.rspec.node",
+    "version": "production",
+    "code_id": null,
+    "catalog_uuid": "89869359-db50-472f-b435-1d37c22be9eb",
+    "catalog_format": 1,
+    "environment": "production",
+    "resources": [
+      {
+        "type": "Stage",
+        "title": "main",
+        "tags": ["stage"],
+        "exported": false,
+        "parameters": {
+          "name": "main"
+        }
+      },
+      {
+        "type": "Class",
+        "title": "Settings",
+        "tags": ["class","settings"],
+        "exported": false
+      }
+    ],
+    "edges": [
+      {
+        "source": "Stage[main]",
+        "target": "Class[Settings]"
+      },
+      {
+        "source": "Stage[main]",
+        "target": "Class[main]"
+      }
+    ],
+    "classes": [
+      "settings"
+    ]
+  }
+}

--- a/spec/octocatalog-diff/fixtures/configs/puppet-master-token.txt
+++ b/spec/octocatalog-diff/fixtures/configs/puppet-master-token.txt
@@ -1,0 +1,1 @@
+secretpuppetmastertoken

--- a/spec/octocatalog-diff/tests/cli/options/puppet_master_api_version_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/puppet_master_api_version_spec.rb
@@ -16,6 +16,12 @@ describe OctocatalogDiff::Cli::Options do
       expect(result[:from_puppet_master_api_version]).to eq(3)
     end
 
+    it 'should handle --puppet-master-api-version with API version 4 as a string' do
+      result = run_optparse(['--puppet-master-api-version', '4'])
+      expect(result[:to_puppet_master_api_version]).to eq(4)
+      expect(result[:from_puppet_master_api_version]).to eq(4)
+    end
+
     it 'should error on --puppet-master-api-version with unsupported API version' do
       expect { run_optparse(['--puppet-master-api-version', '99']) }.to raise_error(ArgumentError)
     end

--- a/spec/octocatalog-diff/tests/cli/options/puppet_master_token_file_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/puppet_master_token_file_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative '../options_helper'
+
+describe OctocatalogDiff::Cli::Options do
+  let(:fixture) { OctocatalogDiff::Spec.fixture_read('configs/puppet-master-token.txt').strip }
+
+  context 'with a relative path' do
+    describe '#opt_puppet_master_token_file' do
+      let(:basedir) { OctocatalogDiff::Spec.fixture_path('configs') }
+
+      it 'should handle --puppet-master-token-file with valid path' do
+        result = run_optparse(['--basedir', basedir, '--puppet-master-token-file', 'puppet-master-token.txt'])
+        expect(result[:to_puppet_master_token]).to eq(fixture)
+        expect(result[:from_puppet_master_token]).to eq(fixture)
+      end
+
+      it 'should error if --puppet_master-token-file points to non-existing file' do
+        expect do
+          run_optparse(['--basedir', basedir, '--puppet-master-token-file', 'sdafjfkjlafjadsasf'])
+        end.to raise_error(Errno::ENOENT)
+      end
+
+      it 'should error if --puppet-master-token-file is not passed an argument' do
+        expect do
+          run_optparse(['--basedir', basedir, '--puppet-master-token-file'])
+        end.to raise_error(OptionParser::MissingArgument)
+      end
+    end
+  end
+
+  context 'with an absolute path' do
+    describe '#opt_puppet_master_token_file' do
+      it 'should handle --puppet-master-token-file with valid path' do
+        result = run_optparse(
+          [
+            '--puppet-master-token-file',
+            OctocatalogDiff::Spec.fixture_path('configs/puppet-master-token.txt')
+          ]
+        )
+        expect(result[:to_puppet_master_token]).to eq(fixture)
+        expect(result[:from_puppet_master_token]).to eq(fixture)
+      end
+
+      it 'should error if --puppet-master-token-file points to non-existing file' do
+        expect do
+          run_optparse(
+            [
+              '--puppet-master-token-file',
+              OctocatalogDiff::Spec.fixture_path('configs/alsdkfalfdkjasdf')
+            ]
+          )
+        end.to raise_error(Errno::ENOENT)
+      end
+    end
+  end
+end

--- a/spec/octocatalog-diff/tests/cli/options/puppet_master_token_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/puppet_master_token_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative '../options_helper'
+
+describe OctocatalogDiff::Cli::Options do
+  describe '#opt_puppet_master_token' do
+    include_examples 'global string option',
+                     'puppet-master-token',
+                     :puppet_master_token
+  end
+end

--- a/spec/octocatalog-diff/tests/cli/options/puppet_master_update_catalog_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/puppet_master_update_catalog_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative '../options_helper'
+
+describe OctocatalogDiff::Cli::Options do
+  describe '#opt_puppet_master_update_catalog' do
+    include_examples 'global true/false option',
+                     'puppet-master-update-catalog',
+                     :puppet_master_update_catalog,
+                     false
+  end
+end

--- a/spec/octocatalog-diff/tests/cli/options/puppet_master_update_facts_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/puppet_master_update_facts_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative '../options_helper'
+
+describe OctocatalogDiff::Cli::Options do
+  describe '#opt_puppet_master_update_facts' do
+    include_examples 'global true/false option',
+                     'puppet-master-update-facts',
+                     :puppet_master_update_facts,
+                     false
+  end
+end

--- a/spec/octocatalog-diff/tests/cli/options_helper.rb
+++ b/spec/octocatalog-diff/tests/cli/options_helper.rb
@@ -84,3 +84,34 @@ RSpec.shared_examples 'global array option' do |cli_flag, key|
     expect(result.key?("to_#{key}".to_sym)).to be(false)
   end
 end
+
+# Some options can be set globally or per branch. This is a shortcut to eliminating
+# repetitive testing code.
+# @param cli_flag [String] The CLI flag
+# @param key [Symbol] Key within options that is set to true or false
+# @param default [Boolean] The expected default value if not otherwise set
+RSpec.shared_examples 'global true/false option' do |cli_flag, key, default|
+  it "should set options[:from_#{key}] and options[:to_#{key}] when --#{cli_flag} is set" do
+    result = run_optparse(["--#{cli_flag}"])
+    expect(result["from_#{key}".to_sym]).to eq(true)
+    expect(result["to_#{key}".to_sym]).to eq(true)
+  end
+
+  it "should set options[:from_#{key}] and options[:to_#{key}] when --no-#{cli_flag} is set" do
+    result = run_optparse(["--no-#{cli_flag}"])
+    expect(result["from_#{key}".to_sym]).to eq(false)
+    expect(result["to_#{key}".to_sym]).to eq(false)
+  end
+
+  it 'should use specific values and global values' do
+    result = run_optparse(["--#{cli_flag}", "--no-from-#{cli_flag}"])
+    expect(result["from_#{key}".to_sym]).to eq(false)
+    expect(result["to_#{key}".to_sym]).to eq(true)
+  end
+
+  it 'should use defaults when no default is specified' do
+    result = run_optparse(["--to-#{cli_flag}"])
+    expect(result["from_#{key}".to_sym]).to eq(default)
+    expect(result["to_#{key}".to_sym]).to be(true)
+  end
+end


### PR DESCRIPTION
<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

## Overview

This pull request [introduces/changes/removes] [functionality/feature].

(Please write a summary of your pull request here. This paragraph should go into detail about what is changing, the motivation behind this change, and the approach you took.)

## Checklist

- [ ] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [ ] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc [related issues] [teams and individuals, making sure to mention why you're CC-ing them]
